### PR TITLE
Fixed compilation warnings

### DIFF
--- a/src/zabbix_agent/logfiles.c
+++ b/src/zabbix_agent/logfiles.c
@@ -18,10 +18,10 @@
 **/
 
 #include "common.h"
+#include "sysinfo.h"
 #include "logfiles.h"
 #include "log.h"
 #include "active.h"
-#include "sysinfo.h"
 
 #if defined(_WINDOWS)
 #	include "symbols.h"

--- a/src/zabbix_agent/zbxconf.c
+++ b/src/zabbix_agent/zbxconf.c
@@ -48,7 +48,7 @@ void load_allowed_paths(char **lines)
 
 	for (pline = lines; NULL != *pline; pline++)
 	{
-		zabbix_log(LOG_LEVEL_DEBUG, "Adding allowed path (%s)", pline);
+		zabbix_log(LOG_LEVEL_DEBUG, "Adding allowed path (%s)", *pline);
 		if (NULL == (p = strchr(*pline, ','))) {
 			add_allowed_path(*pline, NULL);
 		} else {

--- a/src/zabbix_agent/zbxconf.h
+++ b/src/zabbix_agent/zbxconf.h
@@ -56,6 +56,7 @@ extern char	*CONFIG_TLS_PSK_IDENTITY;
 extern char	*CONFIG_TLS_PSK_FILE;
 
 extern char **CONFIG_ALLOWED_PATHS;
+void load_allowed_paths(char **lines);
 
 void	load_aliases(char **lines);
 void	load_user_parameters(char **lines);


### PR DESCRIPTION
Noticed a few compilation warnings when examining agent 4.0 debian package building