### PR TITLE
Iiscrum 843

### DIFF
--- a/frontends/php/include/test.inc.php
+++ b/frontends/php/include/test.inc.php
@@ -165,10 +165,6 @@ function enable_test_maintenance($hostid, $in_maintenance) {
    $next_year = $now + $year;
 	$active_since_date = $now;
    $active_till_date = $next_year;
-   $timeperiod = [{
-      "timeperiod_type": 0,
-      "period": $year
-   }]
 
    if ($in_maintenance == 1) { 
       $test_maintenance = API::Maintenance()->get([
@@ -188,7 +184,10 @@ function enable_test_maintenance($hostid, $in_maintenance) {
          'description' => 'Maintenance for testing tool',
          'active_since' => $active_since_date,
          'active_till' => $active_till_date,
-         'timeperiods' => $timeperiod,
+         'timeperiods' => [{
+            "timeperiod_type": 0,
+            "period": $year
+         }],
          'hostids' => $hostid
       ];
       $result = API::Maintenance()->create($maintenance);

--- a/frontends/php/include/test.inc.php
+++ b/frontends/php/include/test.inc.php
@@ -170,7 +170,7 @@ function enable_test_maintenance($hostid, $in_maintenance) {
       $test_maintenance = API::Maintenance()->get([
          'selectHosts' => ['hostid'],
          'selectTimeperiods' => API_OUTPUT_EXTEND,
-         'filter' => ['name'='Testing maintenance'],
+         'filter' => ['name'=>'Testing maintenance'],
          'output' => ['maintenanceid', 'name', 'active_till']
       ]);
       if ($test_maintenance) {
@@ -184,10 +184,10 @@ function enable_test_maintenance($hostid, $in_maintenance) {
          'description' => 'Maintenance for testing tool',
          'active_since' => $active_since_date,
          'active_till' => $active_till_date,
-         'timeperiods' => [{
-            "timeperiod_type": 0,
-            "period": $year
-         }],
+         'timeperiods' => [
+            "timeperiod_type" => 0,
+            "period" => $year
+         ],
          'hostids' => $hostid
       ];
       $result = API::Maintenance()->create($maintenance);
@@ -215,7 +215,7 @@ function remove_test_maintenance($hostid) {
    $test_maintenance = API::Maintenance()->get([
       'selectHosts' => ['hostid'],
       'selectTimeperiods' => API_OUTPUT_EXTEND,
-      'filter' => ['name'='Testing maintenance'],
+      'filter' => ['name'=>'Testing maintenance'],
       'output' => ['maintenanceid', 'name', 'active_till']
    ]);
 }

--- a/frontends/php/include/test.inc.php
+++ b/frontends/php/include/test.inc.php
@@ -35,7 +35,7 @@ function convert_item_to_test($org_item, $test_value, $test_delay) {
    $result = false;
    $error = false;
    try {
-      enable_test_maintenance($org_item['hostid'], $org_item['host']['maintenance_status']);
+      enable_test_maintenance($org_item['hostid'], $org_item['hosts'][0]['maintenance_status']);
 
       $param_test_value = $test_value;
       $test_item = $org_item;
@@ -162,9 +162,9 @@ function enable_test_maintenance($hostid, $in_maintenance) {
 
    $now = date('Y-m-d+H:i');
    $year = (365 * 24 * 60 * 60);
-   $next_year = $now + $year;
+   $next_year = time() + $year;
 	$active_since_date = $now;
-   $active_till_date = $next_year;
+   $active_till_date = date('Y-m-d+H:i', $next_year);
 
    if ($in_maintenance == 1) { 
       $test_maintenance = API::Maintenance()->get([
@@ -219,6 +219,18 @@ function remove_test_maintenance($hostid) {
       'output' => ['maintenanceid', 'name', 'active_till']
    ]);
 }
+
+/*
+
+   array_merge(): Argument #2 is not an array [items.php:902 → convert_item_to_test() → enable_test_maintenance() → CApiWrapper->__call() → CFrontendApiWrapper->callMethod() → CApiWrapper->callMethod() → 
+   CFrontendApiWrapper->callClientMethod() → CLocalApiClient->callMethod() → CMaintenance->create() → array_merge() in include/classes/api/services/CMaintenance.php:270]
+
+   At least one host group or host must be selected. [items.php:902 → convert_item_to_test() → enable_test_maintenance() → CApiWrapper->__call() → CFrontendApiWrapper->callMethod() → CApiWrapper->callMethod() → 
+   CFrontendApiWrapper->callClientMethod() → CLocalApiClient->callMethod() → CMaintenance->create() → CApiService::exception() in include/classes/api/services/CMaintenance.php:279]
+*/
+
+
+
 
 /*
 {

--- a/frontends/php/include/test.inc.php
+++ b/frontends/php/include/test.inc.php
@@ -94,13 +94,13 @@ function revert_test_to_original($test_item_id) {
       $response = API::Item()->update($item);
 
       if ($response) {
+         $result = remove_from_testing_table($test_item_id);
+         
          $sql_test_items_on_host = 'SELECT COUNT(hostid) AS "hosts" FROM item_testing WHERE hostid=' . zbx_dbstr($item['hostid']);
          $sql_result = DBselect($sql_test_items_on_host);
          $host_test_item_count = DBfetchArray($sql_result)[0]['hosts'];
 
-         $result = remove_from_testing_table($test_item_id);
-         
-         if ($result && $host_test_item_count < 2) {
+         if ($result && !($host_test_item_count > 0)) {
             remove_from_test_maintenance($item['hostid']);
          }
       }
@@ -148,7 +148,11 @@ function add_to_testing_table($item) {
  */
 function remove_from_testing_table($itemid) {
    $result = false;
-   $result = DB::delete('item_testing', array('itemid'=>$itemid));
+   try [
+      $result = DB::delete('item_testing', array('itemid'=>$itemid));
+   ] catch (Exception $e) {
+      $result = true;
+   }
 
    return $result;
 }

--- a/frontends/php/items.php
+++ b/frontends/php/items.php
@@ -903,7 +903,7 @@ elseif (hasRequest('start')) {
 			if ($convert_result) {
 				show_message('Test started');
 			} else {
-            show_error_message('Failed to edit test item.');
+            show_error_message('Failed to enable testing.');
             remove_from_testing_table($item['itemid']);
 			}
 			unset($_REQUEST['itemid'], $_REQUEST['form']);

--- a/frontends/php/items.php
+++ b/frontends/php/items.php
@@ -880,7 +880,8 @@ elseif (hasRequest('start')) {
 				'valuemapid', 'params', 'ipmi_sensor', 'authtype', 'username', 'password', 'publickey', 'privatekey',
 				'interfaceid', 'port', 'description', 'inventory_link', 'lifetime', 'snmpv3_authprotocol',
 				'snmpv3_privprotocol', 'snmpv3_contextname', 'evaltype', 'jmx_endpoint', 'master_itemid'
-			],
+         ],
+         'selectHosts' => ['hostid','maintenance_status'],
 			'itemids' => getRequest('itemid')
 		]);
 		$item = $items[0];
@@ -891,18 +892,19 @@ elseif (hasRequest('start')) {
 		DB::checkValueTypes('item_testing',$item);
 		$error = false;
 		try {
-			$result = add_to_testing_table($item);
+			$add_result = add_to_testing_table($item);
 		} catch (Exception $e) {
 			$error = true;
 			show_error_message($e->getMessage());
 		}
 
 		if (!$error) {
-			$result_bool = convert_item_to_test($org_item, getRequest('test_value'), getRequest('test_delay'));
-			if ($result_bool) {
+			$convert_result = convert_item_to_test($org_item, getRequest('test_value'), getRequest('test_delay'));
+			if ($convert_result) {
 				show_message('Test started');
 			} else {
-				show_error_message('Failed to edit test item.');
+            show_error_message('Failed to edit test item.');
+            remove_from_testing_table($item['itemid']);
 			}
 			unset($_REQUEST['itemid'], $_REQUEST['form']);
 		}
@@ -914,7 +916,7 @@ elseif (hasRequest('action') && getRequest('action') === 'test.stop') {
 		$itemid = getRequest('group_itemid')[0];
 		$error = false;
 		try {
-			$revert_bool = revert_test_to_original($itemid);
+         $revert_bool = revert_test_to_original($itemid);
 		} catch (Exception $e) {
 			$error = true;
 			show_error_message($e->getMessage());

--- a/frontends/php/maintenance.php
+++ b/frontends/php/maintenance.php
@@ -189,6 +189,7 @@ elseif (hasRequest('add') || hasRequest('update')) {
 			$result = API::Maintenance()->update($maintenance);
 		}
 		else {
+         echo("<script>console.log(" . $maintenance . ");</script>");
 			$result = API::Maintenance()->create($maintenance);
 		}
 	}

--- a/frontends/php/maintenance.php
+++ b/frontends/php/maintenance.php
@@ -189,7 +189,6 @@ elseif (hasRequest('add') || hasRequest('update')) {
 			$result = API::Maintenance()->update($maintenance);
 		}
 		else {
-         echo("<script>console.log(" . $maintenance . ");</script>");
 			$result = API::Maintenance()->create($maintenance);
 		}
 	}


### PR DESCRIPTION
Sets host on maintenance when any of it's items is in testing.

Creates 'Testing maintenance' maintenance after first item starts testing, all subsequent hosts that starts testing items, are added to this maintenance. 'Testing maintenance' is hard coded to be active 24/7 for 365 days counting from time of creation. When all items of a host stop testing, the host is removed from maintenance. When all hosts are removed 'Testing maintenance' is removed.

Main PR can be found [here](https://github.com/digiaiiris/iiris/pull/1200).